### PR TITLE
Added wildcard box-sizing to CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,6 +68,12 @@ td { vertical-align: top; }
     Author: Jonathan Verrecchia
    =================================================== */
 
+* {
+    -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+	-moz-box-sizing: border-box;    /* Firefox, other Gecko */
+	box-sizing: border-box;         /* Opera/IE 8+ */
+}
+
 body{ font:16px/24px Helvetica, Helvetica Neue, Arial, sans-serif; }
 
 .wrapper{


### PR DESCRIPTION
Added a wildcard for box-sizing to CSS to simplify box-model math problems. Particularly problematic for adding borders to elements in responsive design. Without box-sizing borders will be added to outside of elements, possibly causing container overflow.
